### PR TITLE
Remove "Rainbox Brackets" extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "esbenp.prettier-vscode",
-    "2gua.rainbow-brackets",
     "bradlc.vscode-tailwindcss"
   ]
 }


### PR DESCRIPTION
We don't need "Rainbow Brackets" extension since VScode supports this feature out-of-box and way faster than this.
I know that this doesn't affect anything but we could avoid the suggestion box at the right bottom

![image](https://user-images.githubusercontent.com/9054528/152664113-0a529957-c786-4f59-a122-0d599c005783.png)
