### PR TITLE
fix for dockerfile npm install step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Install dependencies only when needed
 FROM node:16-alpine AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat git
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm install


### PR DESCRIPTION
When you try to build docker image from Dockerfile it fails on npm install step because alpine image that we use don't have git install